### PR TITLE
Reorganize `Recipe` and friends

### DIFF
--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+use std::fmt::Write;
+
+use serde::{Deserialize, Serialize};
+
+/// Represents an ingredient used in a recipe.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Default, Serialize, Deserialize)]
+pub struct Ingredient {
+    /// The ingredient's display name
+    pub name: String,
+    /// Optional amount of the ingredient to be used
+    pub amount: Option<f32>,
+    /// Optional unit description
+    pub unit: Option<String>,
+}
+
+impl Ingredient {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut ret = String::new();
+
+        if let Some(unit) = &self.unit {
+            write!(ret, "{} ", unit).unwrap();
+        }
+
+        if let Some(amount) = &self.amount {
+            write!(ret, "{} ", amount).unwrap();
+        }
+
+        write!(ret, "{}", self.name).unwrap();
+        ret
+    }
+}
+
+impl fmt::Display for Ingredient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_string())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cookbook;
 pub mod error;
+pub mod ingredient;
 pub mod recipe;
 pub mod render;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cookbook;
 pub mod error;
 pub mod ingredient;
+pub mod metadata;
 pub mod recipe;
 pub mod render;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -30,4 +30,3 @@ impl Display for Metadata {
         write!(f, "{} by {}", self.name, self.author)
     }
 }
-

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,33 @@
+use std::fmt;
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
+pub struct Metadata {
+    /// Display name for the recipe
+    pub name: String,
+    /// Original author of the recipe
+    pub author: String,
+    /// Servings yielded by the recipe as written
+    pub servings: u32,
+    /// Optional URL source of the recipe
+    pub url: Option<String>,
+    /// Optional time in minutes estimated for prep
+    pub prep_minutes: Option<u32>,
+    /// Time in minutes estimated for cooking
+    pub cook_minutes: u32,
+}
+
+impl Metadata {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl Display for Metadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} by {}", self.name, self.author)
+    }
+}
+

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -7,18 +7,8 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use crate::ingredient::Ingredient;
 use crate::{render::RenderSettings, SousError};
-
-/// Container for ingredient metadata
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Ingredient {
-    /// The ingredient's display name
-    pub name: String,
-    /// Optional unit description
-    pub unit: Option<String>,
-    /// Optional amount of the ingredient to be used
-    pub amount: Option<f32>,
-}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Metadata {

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -8,23 +8,8 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::ingredient::Ingredient;
+use crate::metadata::Metadata;
 use crate::{render::RenderSettings, SousError};
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Metadata {
-    /// Display name for the recipe
-    pub name: String,
-    /// Original author of the recipe
-    pub author: String,
-    /// Servings yielded by the recipe as written
-    pub servings: u32,
-    /// Optional URL source of the recipe
-    pub url: Option<String>,
-    /// Optional time in minutes estimated for prep
-    pub prep_minutes: Option<u32>,
-    /// Time in minutes estimated for cooking
-    pub cook_minutes: u32,
-}
 
 /// A Recipe describing how to make a dish
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -12,18 +12,22 @@ use crate::metadata::Metadata;
 use crate::{render::RenderSettings, SousError};
 
 /// A Recipe describing how to make a dish
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Default, Serialize, Deserialize)]
 pub struct Recipe {
     /// Recipe metadata
     #[serde(flatten)]
-    metadata: Metadata,
+    pub metadata: Metadata,
     /// List of steps required to make the dish
-    steps: Vec<String>,
+    pub steps: Vec<String>,
     /// List of `Ingredient`s required to make the dish
-    ingredients: Vec<Ingredient>,
+    pub ingredients: Vec<Ingredient>,
 }
 
 impl Recipe {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
     /// Construct a Markdown-formatted `String` representation of the Recipe
     pub fn to_markdown(&self, settings: &RenderSettings) -> String {
         let mut output = String::new();


### PR DESCRIPTION
This PR moves each Recipe child struct to its own module, along with a couple of changes:

- Struct fields that were not already externally mutable are now `pub`, as these structs are all fairly simple data containers.
- Structs now derive common standard library traits where possible.