### PR TITLE
Create basic library documentation

### DIFF
--- a/src/cookbook.rs
+++ b/src/cookbook.rs
@@ -1,3 +1,5 @@
+//! Types for managing collections of recipes.
+
 use std::{
     fs::read_dir,
     path::{Path, PathBuf},
@@ -5,12 +7,16 @@ use std::{
 
 use crate::{Recipe, SousError};
 
+/// Directory of recipe files.
+///
+/// Stores both the directory's path on the filesystem and a list of found YAML files.
 pub struct Cookbook {
     path: PathBuf,
     recipes: Vec<String>,
 }
 
 impl Cookbook {
+    /// Open a cookbook directory.
     pub fn open(path: &Path) -> Result<Cookbook, SousError> {
         let dir = read_dir(path)?.filter(|entry| match entry {
             Ok(entry) => match entry.path().extension() {
@@ -32,10 +38,12 @@ impl Cookbook {
         Ok(Cookbook { path, recipes })
     }
 
+    /// Get a borrowed [Vec] of available recipe names.
     pub fn recipes(&self) -> &Vec<String> {
         &self.recipes
     }
 
+    /// Load a [Recipe] matching the given name.
     pub fn load_recipe(&self, name: &str) -> Result<Recipe, SousError> {
         Ok(Recipe::from_file(&self.path.join(name))?)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,19 @@
+//! Types representing errors that can occur within Sous.
+
 use thiserror::Error;
 
+/// Errors that can occur within Sous.
 #[derive(Error, Debug)]
 pub enum SousError {
+    /// An error that occurs when parsing YAML.
     #[error(transparent)]
     YamlError(#[from] serde_yaml::Error),
 
+    /// An error involving file I/O; wraps [std::io::Error].
     #[error(transparent)]
     FileError(#[from] std::io::Error),
 
+    /// An unknown internal error, likely indicates a bug.
     #[error("Unknown internal error")]
     Unknown,
 }

--- a/src/ingredient.rs
+++ b/src/ingredient.rs
@@ -1,33 +1,37 @@
+//! Types for representing ingredients.
+
 use std::fmt;
 use std::fmt::Write;
 
 use serde::{Deserialize, Serialize};
 
-/// Represents an ingredient used in a recipe.
+/// An ingredient used in a culinary recipe.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Serialize, Deserialize)]
 pub struct Ingredient {
-    /// The ingredient's display name
+    /// The ingredient's display name.
     pub name: String,
-    /// Optional amount of the ingredient to be used
+    /// Optional amount of the ingredient to be used.
     pub amount: Option<f32>,
-    /// Optional unit description
+    /// Optional unit description.
     pub unit: Option<String>,
 }
 
 impl Ingredient {
+    /// Create a new, empty ingredient.
     pub fn new() -> Self {
         Default::default()
     }
 
+    /// Generate a human-readable [String] representation of the ingredient.
     pub fn to_string(&self) -> String {
         let mut ret = String::new();
 
-        if let Some(unit) = &self.unit {
-            write!(ret, "{} ", unit).unwrap();
-        }
-
         if let Some(amount) = &self.amount {
             write!(ret, "{} ", amount).unwrap();
+        }
+
+        if let Some(unit) = &self.unit {
+            write!(ret, "{} ", unit).unwrap();
         }
 
         write!(ret, "{}", self.name).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,44 @@
+//! Library for handling culinary recipes.
+//!
+//! This crate provides structs representing various components of a culinary
+//! recipe, along with utilities for converting them between various formats.
+//!
+//! ```rust
+//! # use sous::ingredient::Ingredient;
+//! # use sous::recipe::Recipe;
+//! # use sous::render::RenderSettings;
+//! fn main() {
+//!     let mut recipe = Recipe::new();
+//!
+//!     recipe.metadata.name = "Test Recipe".to_string();
+//!     recipe.metadata.author = "Cook Cookerson".to_string();
+//!     recipe.metadata.servings = 2;
+//!     recipe.metadata.cook_minutes = 10;
+//!
+//!     recipe.ingredients.push(Ingredient {
+//!         name: "Ingredient".to_string(),
+//!         amount: Some(1.0),
+//!         ..Default::default()
+//!     });
+//!     recipe.steps.push("First step".to_string());
+//!     recipe.steps.push("Second step".to_string());
+//!
+//!     let md = recipe.to_markdown(&RenderSettings::default());
+//! }
+//! ```
+
+#![warn(missing_docs)]
+
+pub use crate::cookbook::Cookbook;
+pub use crate::error::SousError;
+pub use crate::ingredient::Ingredient;
+pub use crate::metadata::Metadata;
+pub use crate::recipe::Recipe;
+pub use crate::render::RenderSettings;
+
 pub mod cookbook;
 pub mod error;
 pub mod ingredient;
 pub mod metadata;
 pub mod recipe;
 pub mod render;
-
-pub use crate::error::SousError;
-pub use crate::recipe::Recipe;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,25 +1,29 @@
+//! Types for recipe meta information.
+
 use std::fmt;
 use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
+/// Container for recipe meta information.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
 pub struct Metadata {
-    /// Display name for the recipe
+    /// Display name for the recipe.
     pub name: String,
-    /// Original author of the recipe
+    /// Original author of the recipe.
     pub author: String,
-    /// Servings yielded by the recipe as written
+    /// Servings yielded by the recipe as written.
     pub servings: u32,
-    /// Optional URL source of the recipe
+    /// Optional URL source of the recipe.
     pub url: Option<String>,
-    /// Optional time in minutes estimated for prep
+    /// Optional time in minutes estimated for prep.
     pub prep_minutes: Option<u32>,
-    /// Time in minutes estimated for cooking
+    /// Time in minutes estimated for cooking.
     pub cook_minutes: u32,
 }
 
 impl Metadata {
+    /// Create new, empty metadata.
     pub fn new() -> Self {
         Default::default()
     }

--- a/src/recipe.rs
+++ b/src/recipe.rs
@@ -1,3 +1,5 @@
+//! Types for representing culinary recipes.
+
 use std::fmt::Write as FmtWrite;
 use std::io::Write as IoWrite;
 use std::{
@@ -11,24 +13,25 @@ use crate::ingredient::Ingredient;
 use crate::metadata::Metadata;
 use crate::{render::RenderSettings, SousError};
 
-/// A Recipe describing how to make a dish
+/// A culinary recipe describing how to make a dish.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Default, Serialize, Deserialize)]
 pub struct Recipe {
-    /// Recipe metadata
+    /// Recipe [Metadata]..
     #[serde(flatten)]
     pub metadata: Metadata,
-    /// List of steps required to make the dish
+    /// List of steps required to make the dish.
     pub steps: Vec<String>,
-    /// List of `Ingredient`s required to make the dish
+    /// List of [Ingredient]s required to make the dish.
     pub ingredients: Vec<Ingredient>,
 }
 
 impl Recipe {
+    /// Create a new, empty recipe.
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// Construct a Markdown-formatted `String` representation of the Recipe
+    /// Construct a Markdown-formatted [String] representation of the Recipe
     pub fn to_markdown(&self, settings: &RenderSettings) -> String {
         let mut output = String::new();
 
@@ -95,16 +98,19 @@ impl Recipe {
         output
     }
 
+    /// Output this recipe in Markdown to the specified file path.
     pub fn to_file(&self, path: &Path, settings: &RenderSettings) -> Result<(), SousError> {
         let mut output = File::create(path)?;
         write!(output, "{}", self.to_markdown(settings))?;
         Ok(())
     }
 
+    /// Load a recipe from the provided YAML string slice.
     pub fn from_yaml(content: &str) -> Result<Recipe, SousError> {
         Ok(serde_yaml::from_str(content)?)
     }
 
+    /// Load a recipe from the provided file path.
     pub fn from_file(path: &Path) -> Result<Recipe, SousError> {
         let content = fs::read_to_string(path)?;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,13 +1,22 @@
+//! Types for rendering recipes to other formats.
+
+/// Options for rendering a [Recipe](crate::Recipe).
 #[derive(Debug)]
 pub struct RenderSettings {
+    /// Whether to use YAML front matter instead of pure Markdown.
     pub front_matter: bool,
+    /// Whether to output meta information.
     pub meta: bool,
+    /// Whether to output ingredient list.
     pub ingredients: bool,
+    /// Whether to output the procedure.
     pub steps: bool,
+    /// Optionally override the serving count when outputting.
     pub servings: Option<u32>,
 }
 
 impl RenderSettings {
+    /// Create default render settings.
     pub fn new() -> Self {
         Self {
             front_matter: false,


### PR DESCRIPTION
Adds `#![warn(missing_docs)` to the library along with basic doc comments for the entire public API.

Closes #7 